### PR TITLE
Add option to include branch name in slack messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.koant.sonar.slack</groupId>
   <artifactId>cks-slack-notifier</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.3-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>CKS Slack Notifier Plugin</name>
@@ -18,7 +18,7 @@
 
     <!-- JaCoCo support -->
     <argLine />
-    <sonar.version>6.1</sonar.version>
+    <sonar.version>6.7</sonar.version>
   </properties>
 
   <scm>
@@ -37,6 +37,11 @@
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.5</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -146,7 +151,7 @@
           <pluginClass>com.koant.sonar.slacknotifier.SlackNotifierPlugin</pluginClass>
           <pluginName>CKS Slack Notifier</pluginName>
           <pluginDescription>Sends notifications to Slack</pluginDescription>
-          <sonarQubeMinVersion>6.1</sonarQubeMinVersion>
+          <sonarQubeMinVersion>6.5</sonarQubeMinVersion>
           <pluginUrl>https://github.com/kogitant/sonar-slack-notifier-plugin</pluginUrl>
           <pluginIssueTrackerUrl>https://github.com/kogitant/sonar-slack-notifier-plugin/issues</pluginIssueTrackerUrl>
           <pluginSourcesUrl>https://github.com/kogitant/sonar-slack-notifier-plugin</pluginSourcesUrl>

--- a/src/main/java/com/koant/sonar/slacknotifier/SlackNotifierPlugin.java
+++ b/src/main/java/com/koant/sonar/slacknotifier/SlackNotifierPlugin.java
@@ -1,5 +1,15 @@
 package com.koant.sonar.slacknotifier;
 
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.CHANNEL;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.CONFIG;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.ENABLED;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.HOOK;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.INCLUDE_BRANCH;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.NOTIFY;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.PROJECT;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.QG_FAIL_ONLY;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.USER;
+
 import com.koant.sonar.slacknotifier.extension.task.SlackPostProjectAnalysisTask;
 import org.sonar.api.Plugin;
 import org.sonar.api.PropertyType;
@@ -8,8 +18,6 @@ import org.sonar.api.config.PropertyFieldDefinition;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.*;
 
 public class SlackNotifierPlugin implements Plugin {
 
@@ -40,7 +48,7 @@ public class SlackNotifierPlugin implements Plugin {
             .build());
         extensions.add(PropertyDefinition.builder(USER.property())
             .name("Slack user alias")
-            .description("Messages from this plugin appear woth given username")
+            .description("Messages from this plugin appear with given username")
             .defaultValue("SonarQube Slack Notifier Plugin")
             .type(PropertyType.STRING)
             .category(CATEGORY)
@@ -56,7 +64,15 @@ public class SlackNotifierPlugin implements Plugin {
             .subCategory(SUBCATEGORY)
             .index(2)
             .build());
-
+        extensions.add(PropertyDefinition.builder(INCLUDE_BRANCH.property())
+            .name("Branch enabled")
+            .description("Include branch name in slack messages?\nNB: Not supported with free version of SonarQube")
+            .defaultValue("false")
+            .type(PropertyType.BOOLEAN)
+            .category(CATEGORY)
+            .subCategory(SUBCATEGORY)
+            .index(3)
+            .build());
 
         extensions.add(
             PropertyDefinition.builder(CONFIG.property())
@@ -65,7 +81,7 @@ public class SlackNotifierPlugin implements Plugin {
                         "If a slack channel is not configured for a project, no slack message will be sent for project.")
                 .category(CATEGORY)
                 .subCategory(SUBCATEGORY)
-                .index(3)
+                .index(4)
                 .fields(
                     PropertyFieldDefinition.build(PROJECT.property())
                         .name("Project Key")

--- a/src/main/java/com/koant/sonar/slacknotifier/common/SlackNotifierProp.java
+++ b/src/main/java/com/koant/sonar/slacknotifier/common/SlackNotifierProp.java
@@ -8,10 +8,12 @@ public enum SlackNotifierProp {
      * The Slack Incoming Web Hook URL
      */
     HOOK("ckss.hook"),
+
     /**
      * Appear in Slack channels as this user
      */
     USER("ckss.user"),
+
     /**
      * Is this plugin enabled in general?
      * Per project slack notification sending depends on this and a project specific slack channel configuration existing.
@@ -19,9 +21,14 @@ public enum SlackNotifierProp {
     ENABLED("ckss.enabled"),
 
     /**
+     * Include branch name in slack message (only supported in licenced versions of SonarQube)
+     */
+    INCLUDE_BRANCH("ckss.include_branch"),
+
+    /**
      * <p>
      * The project specific slack channels have to be configured in General, server side settings, instead of per project
-     * This property is the prefix for a comma separated valye list of Sonar Project Keys. For every project key there is a slack channel configuration.
+     * This property is the prefix for a comma separated value list of Sonar Project Keys. For every project key there is a slack channel configuration.
      * This is a standard SonarQube way of configuring multivalued fields with org.sonar.api.config.PropertyDefinition.Builder#fields
      * </p>
      * <pre>
@@ -37,10 +44,12 @@ public enum SlackNotifierProp {
      * @see SlackNotifierPlugin#define(org.sonar.api.Plugin.Context)
      */
     CONFIG("ckss.projectconfig"),
+
     /**
      * @see SlackNotifierProp#CONFIG
      */
     PROJECT("project"),
+
     /**
      * @see SlackNotifierProp#CONFIG
      */
@@ -58,12 +67,13 @@ public enum SlackNotifierProp {
 
     private String property;
 
-
     SlackNotifierProp(java.lang.String property) {
+
         this.property = property;
     }
 
     public String property() {
+
         return property;
     }
 }

--- a/src/main/java/com/koant/sonar/slacknotifier/common/component/AbstractSlackNotifyingComponent.java
+++ b/src/main/java/com/koant/sonar/slacknotifier/common/component/AbstractSlackNotifyingComponent.java
@@ -2,12 +2,18 @@ package com.koant.sonar.slacknotifier.common.component;
 
 import com.koant.sonar.slacknotifier.common.SlackNotifierProp;
 import org.sonar.api.ce.posttask.QualityGate;
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -18,10 +24,10 @@ public abstract class AbstractSlackNotifyingComponent {
 
     private static final Logger LOG = Loggers.get(AbstractSlackNotifyingComponent.class);
 
-    private final Settings settings;
+    private final Configuration settings;
     private Map<String, ProjectConfig> projectConfigMap = Collections.emptyMap();
 
-    public AbstractSlackNotifyingComponent(Settings settings) {
+    public AbstractSlackNotifyingComponent(Configuration settings) {
         this.settings = settings;
         LOG.info("Constructor called, project slack channel config map constructed from general settings");
     }
@@ -43,9 +49,9 @@ public abstract class AbstractSlackNotifyingComponent {
 
     private void refreshProjectConfigs() {
         LOG.info("Refreshing project configs");
-        Set<ProjectConfig> oldValues = new HashSet<>();
-        this.projectConfigMap.values().forEach(c -> oldValues.add(new ProjectConfig(c)));
-        this.projectConfigMap = buildProjectConfigByProjectKeyMap(settings);
+        Set<ProjectConfig> oldValues =  this.projectConfigMap.values().stream().
+            map(ProjectConfig::new).collect(Collectors.toSet());
+        this.projectConfigMap = buildProjectConfigByProjectKeyMap(this.settings);
         Set<ProjectConfig> newValues = new HashSet<>(this.projectConfigMap.values());
         if (!oldValues.equals(newValues)) {
             LOG.info("Old configs [{}] --> new configs [{}]", oldValues, newValues);
@@ -53,15 +59,28 @@ public abstract class AbstractSlackNotifyingComponent {
     }
 
     protected String getSlackIncomingWebhookUrl() {
-        return settings.getString(SlackNotifierProp.HOOK.property());
+
+        Optional<String> hook = settings.get(SlackNotifierProp.HOOK.property());
+        return hook.orElseThrow(() -> new IllegalStateException("Hook property not found"));
     }
 
     protected String getSlackUser() {
-        return settings.getString(SlackNotifierProp.USER.property());
+
+        Optional<String> user = settings.get(SlackNotifierProp.USER.property());
+        return user.orElseThrow(() -> new IllegalStateException("User property not found"));
     }
 
     protected boolean isPluginEnabled() {
-        return settings.getBoolean(SlackNotifierProp.ENABLED.property());
+        return settings.getBoolean(SlackNotifierProp.ENABLED.property()).orElseThrow(()
+            -> new IllegalStateException("Enabled property not found"));
+    }
+
+    /**
+     * @return value for INCLUDE_BRANCH property, defaults to false if for some reason not set.
+     */
+    protected boolean isBranchEnabled() {
+
+        return settings.getBoolean(SlackNotifierProp.INCLUDE_BRANCH.property()).orElse(false);
     }
 
     /**
@@ -70,14 +89,15 @@ public abstract class AbstractSlackNotifyingComponent {
      * @return
      */
     protected String getSonarServerUrl() {
-        String u = settings.getString("sonar.core.serverBaseURL");
-        if (u == null) {
+        Optional<String> urlOptional = settings.get("sonar.core.serverBaseURL");
+        if (!urlOptional.isPresent()) {
             return null;
         }
-        if (u.endsWith("/")) {
-            return u;
+        String url = urlOptional.get();
+        if (url.endsWith("/")) {
+            return url;
         }
-        return u + "/";
+        return url + "/";
     }
 
     protected Optional<ProjectConfig> getProjectConfig(String projectKey) {
@@ -99,20 +119,20 @@ public abstract class AbstractSlackNotifyingComponent {
         return Optional.of(projectConfigs.get(0));
     }
 
-    private static Map<String, ProjectConfig> buildProjectConfigByProjectKeyMap(Settings settings) {
+    private static Map<String, ProjectConfig> buildProjectConfigByProjectKeyMap(Configuration settings) {
         Map<String, ProjectConfig> map = new HashMap<>();
         String[] projectConfigIndexes = settings.getStringArray(SlackNotifierProp.CONFIG.property());
         LOG.info("SlackNotifierProp.CONFIG=[{}]", projectConfigIndexes);
         for (String projectConfigIndex : projectConfigIndexes) {
             String projectKeyProperty = SlackNotifierProp.CONFIG.property() + "." + projectConfigIndex + "." + SlackNotifierProp.PROJECT.property();
-            String projectKey = settings.getString(projectKeyProperty);
-            if (projectKey == null) {
+            Optional<String> projectKey = settings.get(projectKeyProperty);
+            if (!projectKey.isPresent()) {
                 throw MessageException.of("Slack notifier configuration is corrupted. At least one project specific parameter has no project key. " +
                         "Contact your administrator to update this configuration in the global administration section of SonarQube.");
             }
             ProjectConfig value = ProjectConfig.create(settings, projectConfigIndex);
             LOG.info("Found project configuration [{}]", value);
-            map.put(projectKey, value);
+            map.put(projectKey.get(), value);
         }
         return map;
     }
@@ -123,11 +143,12 @@ public abstract class AbstractSlackNotifyingComponent {
         mapSetting(pluginSettings, SlackNotifierProp.USER);
         mapSetting(pluginSettings, SlackNotifierProp.ENABLED);
         mapSetting(pluginSettings, SlackNotifierProp.CONFIG);
+        mapSetting(pluginSettings, SlackNotifierProp.INCLUDE_BRANCH);
         return pluginSettings.toString() + "; project specific channel config: " + projectConfigMap;
     }
 
     private void mapSetting(Map<String, String> pluginSettings, SlackNotifierProp key) {
-        pluginSettings.put(key.name(), settings.getString(key.property()));
+        pluginSettings.put(key.name(), settings.get(key.property()).orElse(""));
     }
 
     protected boolean shouldSkipSendingNotification(ProjectConfig projectConfig, QualityGate qualityGate) {

--- a/src/main/java/com/koant/sonar/slacknotifier/extension/task/SlackPostProjectAnalysisTask.java
+++ b/src/main/java/com/koant/sonar/slacknotifier/extension/task/SlackPostProjectAnalysisTask.java
@@ -6,7 +6,7 @@ import com.github.seratch.jslack.api.webhook.WebhookResponse;
 import com.koant.sonar.slacknotifier.common.component.AbstractSlackNotifyingComponent;
 import com.koant.sonar.slacknotifier.common.component.ProjectConfig;
 import org.sonar.api.ce.posttask.PostProjectAnalysisTask;
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.i18n.I18n;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -25,11 +25,12 @@ public class SlackPostProjectAnalysisTask extends AbstractSlackNotifyingComponen
     private final I18n i18n;
     private final Slack slackClient;
 
-    public SlackPostProjectAnalysisTask(Settings settings, I18n i18n) {
+    public SlackPostProjectAnalysisTask(Configuration settings, I18n i18n) {
+
         this(Slack.getInstance(), settings, i18n);
     }
 
-    public SlackPostProjectAnalysisTask(Slack slackClient, Settings settings, I18n i18n) {
+    public SlackPostProjectAnalysisTask(Slack slackClient, Configuration settings, I18n i18n) {
         super(settings);
         this.slackClient = slackClient;
         this.i18n = i18n;
@@ -55,12 +56,15 @@ public class SlackPostProjectAnalysisTask extends AbstractSlackNotifyingComponen
             return;
         }
 
+
+
         LOG.info("Slack notification will be sent: " + analysis.toString());
 
         Payload payload = ProjectAnalysisPayloadBuilder.of(analysis)
                 .i18n(i18n)
                 .projectConfig(projectConfig)
                 .projectUrl(projectUrl(projectKey))
+                .includeBranch(isBranchEnabled())
                 .username(getSlackUser())
                 .build();
 

--- a/src/test/java/com/koant/sonar/slacknotifier/extension/task/Analyses.java
+++ b/src/test/java/com/koant/sonar/slacknotifier/extension/task/Analyses.java
@@ -1,11 +1,19 @@
 package com.koant.sonar.slacknotifier.extension.task;
 
-import org.sonar.api.ce.posttask.*;
+import static org.sonar.api.ce.posttask.PostProjectAnalysisTaskTester.newCeTaskBuilder;
+import static org.sonar.api.ce.posttask.PostProjectAnalysisTaskTester.newConditionBuilder;
+import static org.sonar.api.ce.posttask.PostProjectAnalysisTaskTester.newQualityGateBuilder;
+import static org.sonar.api.ce.posttask.PostProjectAnalysisTaskTester.newScannerContextBuilder;
+
+import org.sonar.api.ce.posttask.Branch;
+import org.sonar.api.ce.posttask.CeTask;
+import org.sonar.api.ce.posttask.PostProjectAnalysisTask;
+import org.sonar.api.ce.posttask.PostProjectAnalysisTaskTester;
+import org.sonar.api.ce.posttask.Project;
+import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.measures.CoreMetrics;
 
 import java.util.Date;
-
-import static org.sonar.api.ce.posttask.PostProjectAnalysisTaskTester.*;
 
 public class Analyses {
 
@@ -25,8 +33,7 @@ public class Analyses {
         PostProjectAnalysisTaskTester.of(analysisTask)
                 .withCeTask(CE_TASK)
                 .withProject(PROJECT)
-                .withScannerContext(newScannerContextBuilder()
-                .build())
+                .withScannerContext(newScannerContextBuilder().build())
                 .at(new Date())
                 .withQualityGate(
                         newQualityGateBuilder()
@@ -43,6 +50,7 @@ public class Analyses {
                                 .build())
                 .execute();
     }
+
 
     public static void simpleDifferentKey(PostProjectAnalysisTask analysisTask) {
         PostProjectAnalysisTaskTester.of(analysisTask)
@@ -146,5 +154,15 @@ public class Analyses {
                 .withProject(PROJECT)
                 .at(new Date())
                 .execute();
+    }
+
+    public static void withBranch(PostProjectAnalysisTask analysisTask, Branch branch) {
+        PostProjectAnalysisTaskTester.of(analysisTask)
+            .withCeTask(CE_TASK)
+            .withProject(PROJECT)
+            .withBranch(branch)
+            .at(new Date())
+            .withScannerContext(newScannerContextBuilder().build())
+            .execute();
     }
 }

--- a/src/test/java/com/koant/sonar/slacknotifier/extension/task/ProjectAnalysisPayloadBuilderTest.java
+++ b/src/test/java/com/koant/sonar/slacknotifier/extension/task/ProjectAnalysisPayloadBuilderTest.java
@@ -6,11 +6,13 @@ import com.github.seratch.jslack.api.model.Attachment;
 import com.github.seratch.jslack.api.model.Field;
 import com.github.seratch.jslack.api.webhook.Payload;
 import com.koant.sonar.slacknotifier.common.component.ProjectConfig;
-
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.sonar.api.ce.posttask.Branch;
 import org.sonar.api.utils.System2;
 import org.sonar.core.i18n.DefaultI18n;
 import org.sonar.core.platform.PluginRepository;
@@ -18,6 +20,7 @@ import org.sonar.core.platform.PluginRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Created by ak on 18/10/16.
@@ -25,10 +28,10 @@ import java.util.Locale;
  */
 public class ProjectAnalysisPayloadBuilderTest {
     private static final boolean QG_FAIL_ONLY = true;
-    CaptorPostProjectAnalysisTask postProjectAnalysisTask;
-    DefaultI18n i18n;
-    
-    Locale defaultLocale;
+    private CaptorPostProjectAnalysisTask postProjectAnalysisTask;
+    private DefaultI18n i18n;
+
+    private Locale defaultLocale;
 
     @Before
     public void before() {
@@ -43,11 +46,11 @@ public class ProjectAnalysisPayloadBuilderTest {
         defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
     }
-    
+
     @After
     public void after(){
         Locale.setDefault(defaultLocale);
-        
+
     }
 
     @Test
@@ -112,7 +115,7 @@ public class ProjectAnalysisPayloadBuilderTest {
     }
 
     @Test
-    public void shouldShowOnlyExceededConditionsIfProjectConfigReportOnlyOnFailedQualityGateWay() throws Exception {
+    public void shouldShowOnlyExceededConditionsIfProjectConfigReportOnlyOnFailedQualityGateWay() {
         Analyses.qualityGateError2Of3ConditionsFailed(postProjectAnalysisTask);
         ProjectConfig projectConfig = new ProjectConfig("key", "#channel", "here", QG_FAIL_ONLY);
         Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
@@ -131,7 +134,7 @@ public class ProjectAnalysisPayloadBuilderTest {
     }
 
     @Test
-    public void buildPayloadWithoutQualityGateWay() throws Exception {
+    public void buildPayloadWithoutQualityGateWay() {
         Analyses.noQualityGate(postProjectAnalysisTask);
         ProjectConfig projectConfig = new ProjectConfig("key", "#channel", "here", false);
         Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
@@ -146,7 +149,7 @@ public class ProjectAnalysisPayloadBuilderTest {
     }
 
     @Test
-    public void buildPayloadWithoutNotify() throws Exception {
+    public void buildPayloadWithoutNotify() {
         Analyses.noQualityGate(postProjectAnalysisTask);
         ProjectConfig projectConfig = new ProjectConfig("key", "#channel", "", false);
         Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
@@ -158,5 +161,90 @@ public class ProjectAnalysisPayloadBuilderTest {
 
         assertThat(payload.getAttachments()).isNull();
         assertThat(payload.getText()).doesNotContain("here");
+    }
+
+    @Test
+    public void build_noBranch_notifyPrefixAppended(){
+        Analyses.noQualityGate(postProjectAnalysisTask);
+        String notify = RandomStringUtils.random(10);
+        Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
+            .projectConfig(new ProjectConfig("key", "#channel", notify, false))
+            .i18n(i18n)
+            .projectUrl("http://localhost:9000/dashboard?id=project:key")
+            .username("CKSSlackNotifier")
+            .build();
+        Assert.assertEquals(String.format("<!%s> Project [Project Name] analyzed. See http://localhost:9000/dashboard?id=project:key.",
+            notify), payload.getText());
+    }
+
+    @Test
+    public void build_mainBranch_branchNotAddedToMessage(){
+
+        String branchName = "my-branch";
+        boolean isMain = true;
+
+        Analyses.withBranch(postProjectAnalysisTask, newBranch(branchName, isMain));
+        Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
+            .projectConfig(new ProjectConfig("key", "#channel", "", false))
+            .i18n(i18n)
+            .projectUrl("http://localhost:9000/dashboard?id=project:key")
+            .username("CKSSlackNotifier")
+            .includeBranch(true)
+            .build();
+        Assert.assertEquals("Project [Project Name] analyzed. See http://localhost:9000/dashboard?id=project:key.", payload.getText());
+    }
+
+    @Test
+    public void build_withIncludeBranchTrue_branchAddedToMessage(){
+
+        String branchName = RandomStringUtils.random(10);
+        Analyses.withBranch(postProjectAnalysisTask, newBranch(branchName, false));
+        Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
+            .projectConfig(new ProjectConfig("key", "#channel", "", false))
+            .i18n(i18n)
+            .projectUrl("http://localhost:9000/dashboard?id=project:key")
+            .username("CKSSlackNotifier")
+            .includeBranch(true)
+            .build();
+        Assert.assertEquals(String.format("Project [Project Name] analyzed for branch [%s]. See http://localhost:9000/dashboard?id=project:key.",
+            branchName), payload.getText());
+    }
+
+    @Test
+    public void build_enabledButNoBranchPresent_branchNotAddedToMessage(){
+
+        Analyses.simple(postProjectAnalysisTask);
+        Payload payload = ProjectAnalysisPayloadBuilder.of(postProjectAnalysisTask.getProjectAnalysis())
+            .projectConfig(new ProjectConfig("key", "#channel", "", false))
+            .i18n(i18n)
+            .projectUrl("http://localhost:9000/dashboard?id=project:key")
+            .username("CKSSlackNotifier")
+            .includeBranch(true)
+            .build();
+        Assert.assertEquals("Project [Project Name] analyzed. See http://localhost:9000/dashboard?id=project:key. Quality gate status: OK", payload.getText());
+    }
+
+    private Branch newBranch(String name, boolean isMain) {
+
+        return new Branch() {
+
+                  @Override
+                  public boolean isMain() {
+
+                      return isMain;
+                  }
+
+                  @Override
+                  public Optional<String> getName() {
+
+                      return Optional.of(name);
+                  }
+
+                  @Override
+                  public Type getType() {
+
+                      return Type.SHORT;
+                  }
+              };
     }
 }

--- a/src/test/java/com/koant/sonar/slacknotifier/extension/task/SlackPostProjectAnalysisTaskTest.java
+++ b/src/test/java/com/koant/sonar/slacknotifier/extension/task/SlackPostProjectAnalysisTaskTest.java
@@ -1,27 +1,42 @@
 package com.koant.sonar.slacknotifier.extension.task;
 
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.CHANNEL;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.CONFIG;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.ENABLED;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.INCLUDE_BRANCH;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.PROJECT;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.QG_FAIL_ONLY;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.USER;
+import static com.koant.sonar.slacknotifier.extension.task.Analyses.PROJECT_KEY;
+import static java.lang.String.format;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.webhook.Payload;
 import com.github.seratch.jslack.api.webhook.WebhookResponse;
 import com.koant.sonar.slacknotifier.common.SlackNotifierProp;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.sonar.api.config.MapSettings;
+import org.sonar.api.ce.posttask.Branch;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.ConfigurationBridge;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.i18n.I18n;
 
 import java.io.IOException;
 import java.util.Locale;
-
-import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.*;
-import static com.koant.sonar.slacknotifier.extension.task.Analyses.PROJECT_KEY;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import java.util.Optional;
 
 /**
  * Created by 616286 on 3.6.2016.
@@ -30,18 +45,19 @@ import static org.mockito.Mockito.when;
 public class SlackPostProjectAnalysisTaskTest {
 
     private static final String HOOK = "hook";
-    private static final String DIFFERENT_KEY = "different:key";
 
-    CaptorPostProjectAnalysisTask postProjectAnalysisTask;
-    SlackPostProjectAnalysisTask task;
+    private CaptorPostProjectAnalysisTask postProjectAnalysisTask;
+    private SlackPostProjectAnalysisTask task;
     private Slack slackClient;
     private Settings settings;
-    I18n i18n;
+    private Configuration configuration;
+
+    private I18n i18n;
 
     @Before
     public void before() throws IOException {
         postProjectAnalysisTask = new CaptorPostProjectAnalysisTask();
-        settings = new MapSettings();
+        this.settings = new MapSettings();
         settings.setProperty(ENABLED.property(), "true");
         settings.setProperty(SlackNotifierProp.HOOK.property(), HOOK);
         settings.setProperty(CHANNEL.property(), "channel");
@@ -51,17 +67,14 @@ public class SlackPostProjectAnalysisTaskTest {
         settings.setProperty(CONFIG.property() + "." + PROJECT_KEY + "." + CHANNEL.property(), "#random");
         settings.setProperty(CONFIG.property() + "." + PROJECT_KEY + "." + QG_FAIL_ONLY.property(), "false");
         settings.setProperty("sonar.core.serverBaseURL", "http://your.sonar.com/");
+        this.configuration = new ConfigurationBridge(settings);
         slackClient = Mockito.mock(Slack.class);
         WebhookResponse webhookResponse = WebhookResponse.builder().code(200).build();
         when(slackClient.send(anyString(), any(Payload.class))).thenReturn(webhookResponse);
         i18n = Mockito.mock(I18n.class);
-        Mockito.when(i18n.message(Matchers.any(Locale.class), anyString(), anyString())).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                return (String) invocation.getArguments()[2];
-            }
-        });
-        task = new SlackPostProjectAnalysisTask(slackClient, settings, i18n);
+        Mockito.when(i18n.message(Matchers.any(Locale.class), anyString(), anyString())).thenAnswer(
+            (Answer<String>) invocation -> (String) invocation.getArguments()[2]);
+        task = new SlackPostProjectAnalysisTask(slackClient, configuration, i18n);
     }
 
     @Test
@@ -72,7 +85,7 @@ public class SlackPostProjectAnalysisTaskTest {
     }
 
     @Test
-    public void shouldSkipIfPluginDisabled() throws Exception {
+    public void shouldSkipIfPluginDisabled() {
         settings.setProperty(ENABLED.property(), "false");
         Analyses.simple(postProjectAnalysisTask);
         task.finished(postProjectAnalysisTask.getProjectAnalysis());
@@ -80,17 +93,75 @@ public class SlackPostProjectAnalysisTaskTest {
     }
 
     @Test
-    public void shouldSkipIfNoConfigFound() throws Exception {
+    public void shouldSkipIfNoConfigFound() {
         Analyses.simpleDifferentKey(postProjectAnalysisTask);
         task.finished(postProjectAnalysisTask.getProjectAnalysis());
         Mockito.verifyZeroInteractions(slackClient);
     }
 
     @Test
-    public void shouldSkipIfReportFailedQualityGateButOk() throws Exception {
+    public void shouldSkipIfReportFailedQualityGateButOk() {
         settings.setProperty(CONFIG.property() + "." + PROJECT_KEY + "." + QG_FAIL_ONLY.property(), "true");
         Analyses.simple(postProjectAnalysisTask);
         task.finished(postProjectAnalysisTask.getProjectAnalysis());
         Mockito.verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void shouldIncludeBranchWhenEnabledAndPresent() throws IOException {
+        String branchName = RandomStringUtils.random(13);
+        settings.setProperty(INCLUDE_BRANCH.property(), "true");
+        Analyses.withBranch(postProjectAnalysisTask, newBranch(false, branchName));
+        task.finished(postProjectAnalysisTask.getProjectAnalysis());
+        ArgumentCaptor<Payload> arg = ArgumentCaptor.forClass(Payload.class);
+        Mockito.verify(slackClient, times(1)).send(anyString(), arg.capture());
+        Assert.assertTrue(arg.getValue().getText().contains(format("analyzed for branch [%s]", branchName)));
+    }
+
+    @Test
+    public void shouldNotIncludeBranchWhenDisabled() throws IOException {
+
+        settings.setProperty(INCLUDE_BRANCH.property(), "false");
+        Analyses.withBranch(postProjectAnalysisTask, newBranch(false, "branchName"));
+        task.finished(postProjectAnalysisTask.getProjectAnalysis());
+        ArgumentCaptor<Payload> arg = ArgumentCaptor.forClass(Payload.class);
+        Mockito.verify(slackClient, times(1)).send(anyString(), arg.capture());
+        Assert.assertFalse(arg.getValue().getText().contains("branch"));
+    }
+
+    @Test
+    public void shouldNotIncludeMainBranch() throws IOException {
+
+        settings.setProperty(INCLUDE_BRANCH.property(), "true");
+        Analyses.withBranch(postProjectAnalysisTask, newBranch(true, "branchName"));
+        task.finished(postProjectAnalysisTask.getProjectAnalysis());
+        ArgumentCaptor<Payload> arg = ArgumentCaptor.forClass(Payload.class);
+        Mockito.verify(slackClient, times(1)).send(anyString(), arg.capture());
+        Assert.assertFalse(arg.getValue().getText().contains("branch"));
+    }
+
+
+    private static Branch newBranch(boolean main, String name) {
+
+        return new Branch() {
+
+            @Override
+            public boolean isMain() {
+
+                return main;
+            }
+
+            @Override
+            public Optional<String> getName() {
+
+                return Optional.of(name);
+            }
+
+            @Override
+            public Branch.Type getType() {
+
+                return Type.SHORT;
+            }
+        };
     }
 }

--- a/src/test/java/slacknotifier/SlackNotifierPluginTest.java
+++ b/src/test/java/slacknotifier/SlackNotifierPluginTest.java
@@ -1,0 +1,66 @@
+package slacknotifier;
+
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.CONFIG;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.ENABLED;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.HOOK;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.INCLUDE_BRANCH;
+import static com.koant.sonar.slacknotifier.common.SlackNotifierProp.USER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.koant.sonar.slacknotifier.SlackNotifierPlugin;
+import com.koant.sonar.slacknotifier.extension.task.SlackPostProjectAnalysisTask;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.sonar.api.Plugin;
+import org.sonar.api.config.PropertyDefinition;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SlackNotifierPluginTest {
+
+    private SlackNotifierPlugin plugin = new SlackNotifierPlugin();
+
+    @Test
+    public void define_expectedExtensionsAdded() {
+
+        Plugin.Context mockContext = mock(Plugin.Context.class);
+        plugin.define(mockContext);
+        ArgumentCaptor<List> arg = ArgumentCaptor.forClass(List.class);
+        verify(mockContext, times(1)).addExtensions(arg.capture());
+
+        List extensions = arg.getValue();
+        Assert.assertEquals(6, extensions.size());
+        Assert.assertEquals(HOOK.property(), ((PropertyDefinition) extensions.get(0)).key());
+        Assert.assertEquals(USER.property(), ((PropertyDefinition) extensions.get(1)).key());
+        Assert.assertEquals(ENABLED.property(), ((PropertyDefinition) extensions.get(2)).key());
+        Assert.assertEquals(INCLUDE_BRANCH.property(),
+            ((PropertyDefinition) extensions.get(3)).key());
+        Assert.assertEquals(CONFIG.property(), ((PropertyDefinition) extensions.get(4)).key());
+        Assert.assertEquals(SlackPostProjectAnalysisTask.class, extensions.get(5));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void define_noDupliacteIndexes() {
+
+        Plugin.Context mockContext = mock(Plugin.Context.class);
+        plugin.define(mockContext);
+        ArgumentCaptor<List> arg = ArgumentCaptor.forClass(List.class);
+        verify(mockContext, times(1)).addExtensions(arg.capture());
+
+        List<Object> extensions = arg.getValue();
+
+        Set<Integer> indexes = extensions.stream().filter(PropertyDefinition.class::isInstance)
+            .map(PropertyDefinition.class::cast).map(PropertyDefinition::index).
+                collect(Collectors.toSet());
+        Assert.assertEquals(5, indexes.size());
+
+    }
+
+}


### PR DESCRIPTION
Add option to include branch name in messages sent to slack.
Branch information will never be included if using the free
version of SonarQube, even when the plugin option is enabled.

Update SonarQube API to 6.7, branch information is not available
in earlier versions.

Code cleanup:
* Replace most uses of deprecated Settings with Configuration
* Follow some suggestions from SonarQube's.
* Use apache commons-lang instead of provided version.
  Trying to use org.sonar.api.internal.apachecommons.lang.StringUtils
  lead to NoSuchMethodException.